### PR TITLE
Remove hpc-coveralls --print-response deprecated flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ script:
   - run-cabal-test --show-details=always
 
 after_script:
-  - hpc-coveralls --exclude-dir=tests --exclude-dir=lib/Ceilometer/Types/TH.hs --print-response --coverage-mode=AllowPartialLines unit
+  - hpc-coveralls --exclude-dir=tests --exclude-dir=lib/Ceilometer/Types/TH.hs --coverage-mode=AllowPartialLines unit


### PR DESCRIPTION
I've just released a new version of hpc-coveralls in which the `--print-response` flag was removed, and replaced by `--curl-verbose`.
I guess you may have used this flag originally to troubleshoot hpc-coveralls failures, but as there doesn't seem to be any problem left, it's not needed anymore.
If you ever have any problem again, you can now use the `--curl-verbose` flag instead.
