### PR TITLE
Fix retained results when stripping time before fold

### DIFF
--- a/lib/Ceilometer/Fold.hs
+++ b/lib/Ceilometer/Fold.hs
@@ -209,14 +209,17 @@ foldImagePollster  =  L.Fold (sGaugePollster $ const True) bGaugePollster snd
 
 -- Utilities -------------------------------------------------------------------
 
--- | Wrap a fold that doens't depend on time with dummy times.
---   note: useful to give a unified interface to clients (borel) while keeping
---         concerns separate for testing.
+-- | Wrap a fold that doens't depend on time.
 --
+-- 
 timewrapFold :: L.Fold x y -> L.Fold (Timed x) y
-timewrapFold (L.Fold s b e)
-  = L.Fold (\a (Timed _ x) -> s a x) b e
-{-# INLINE timewrapFold #-}
+timewrapFold (L.Fold s b e) = L.Fold (\a (Timed _ x) -> s a x) b e
+
+-- We want the result to not be retained, inlining this transform doesn't help.
+{-# NOINLINE timewrapFold #-}
+{-# RULES
+"timewrapFold" forall s b e. timewrapFold (L.Fold s b e) = L.Fold (\a (Timed _ x) -> s a x) b e
+  #-}
 
 
 -- Common Steps ----------------------------------------------------------------


### PR DESCRIPTION
I have some folds that don't depend on timestamps of the values and some that do. Previously there was a function `timewrapFold` that make these 2 folds compatible (simply stripping the timestamps for those folds that don't need them).

This was retaining the result of the fold, inlining doesn't help. This change uses rewrite rules to make sure the result isn't retained. The heap profile is much flatter now.
