### PR TITLE
Improve performance

### DIFF
--- a/lib/Ceilometer/Client.hs
+++ b/lib/Ceilometer/Client.hs
@@ -122,9 +122,12 @@ decode
   :: (Known a, Monad m)
   => Env
   -> Pipe SimplePoint (Maybe (Timed a)) m ()
-decode env = forever $ do
-  SimplePoint _ (TimeStamp t) v <- await
-  yield $ T.sequence $ Timed t $ v ^? clonePrism (mkPrism env)
+decode env
+  = let p = clonePrism (mkPrism env)
+    in  forever $ {-# SCC actual_decode #-} do
+          SimplePoint _ (TimeStamp t) v <- await
+          yield $ T.sequence $ Timed t $ v ^? p
+{-# INLINE decode #-}
 
 foldDecoded
   :: (Known a, Monad m)
@@ -132,10 +135,13 @@ foldDecoded
   -> Producer (Timed a) m ()
   -> m FoldResult
 foldDecoded env = impurely P.foldM (generalize $ mkFold env)
+{-# INLINE foldDecoded #-}
 
 -- | Abort the entire pipeline when encoutering malformed data in the Vault.
 --
 blowup :: Monad m => Pipe (Maybe x) x m r
-blowup = forever $ do
+blowup = forever $ {-# SCC blowup #-} do
   x <- await
-  maybe (error "fatal: unparseable point") yield x
+  --maybe (error "fatal: unparseable point") yield x
+  maybe (return ()) yield x
+{-# INLINE blowup #-}

--- a/lib/Ceilometer/Fold.hs
+++ b/lib/Ceilometer/Fold.hs
@@ -305,7 +305,8 @@ sGaugePollster
   => (x -> Bool) -> AGaugePollster x -> Timed x -> AGaugePollster x
 sGaugePollster _          (Nothing,            acc) x =  (Just x, acc)
 sGaugePollster isBillable (Just (Timed t1 v1), acc) x@(Timed t2 _)
-  = let delta = t2 - t1
+  = {-# SCC loop_body #-}
+    let delta = t2 - t1
         !acc' = if   isBillable v1
                 then insertVal v1 (fromIntegral delta) acc
                 else acc

--- a/lib/Ceilometer/Types.hs
+++ b/lib/Ceilometer/Types.hs
@@ -58,7 +58,7 @@ module Ceilometer.Types
 
     -- * Values
   , Valued, value
-  , Timed(Timed), time
+  , Timed(..), time
 
     -- * Interface
   , Env(..), Filters(..)
@@ -105,8 +105,10 @@ filterByInstanceStatus (Filters f) g = f . g
 
 -- | Values with a TimeStamp.
 --
-data Timed value = Timed { _time :: !Word64, _val :: value }
-     deriving (Show, Functor, Foldable, Traversable)
+data Timed value = Timed
+  { _time :: {-# UNPACK #-} !Word64
+  , _val  :: {-# UNPACK #-} !value }
+  deriving (Show, Functor, Foldable, Traversable)
 
 makeLenses ''Timed
 

--- a/lib/Ceilometer/Types/Base.hs
+++ b/lib/Ceilometer/Types/Base.hs
@@ -48,6 +48,7 @@ newtype PRSimple = PRSimple { _prSimpleVal :: Word64 }
 
 prSimple :: Iso' Word64 PRSimple
 prSimple = iso PRSimple _prSimpleVal
+{-# INLINE prSimple #-}
 
 -- | Payload Raw Compound Event
 --
@@ -81,6 +82,7 @@ prCompoundEvent = iso getIt putIt
           B.putWord8    $ x ^. eventEndpoint
           B.putWord8    $ x ^. eventVerb
           B.putWord8    $ x ^. eventStatus
+{-# INLINE prCompoundEvent #-}
 
 data PRCompoundPollster = PRCompoundPollster
   { _pollsterVal    :: {-# UNPACK #-} !Word32 -- ^ Payload
@@ -109,6 +111,7 @@ prCompoundPollster = iso getIt putIt
           B.putWord8      0
           B.putWord8      0
           B.putWord8    $ x ^. pollsterStatus
+{-# INLINE prCompoundPollster #-}
 
 
 -- Decoded Payload Fields ------------------------------------------------------

--- a/lib/Ceilometer/Types/Instance.hs
+++ b/lib/Ceilometer/Types/Instance.hs
@@ -60,8 +60,10 @@ $(declarePF    "Instance"
 
 -- BOILERPLATE GALORE
 
-data PDInstanceVCPU = PDInstanceVCPU PFInstanceStatus PFValue32
-     deriving (Eq, Show, Read)
+data PDInstanceVCPU = PDInstanceVCPU
+  {-# UNPACK #-} !PFInstanceStatus
+  {-# UNPACK #-} !PFValue32
+  deriving (Eq, Show, Read)
 
 pdInstanceVCPU :: Prism' PRCompoundPollster PDInstanceVCPU
 pdInstanceVCPU = prism' pretty parse
@@ -73,9 +75,12 @@ pdInstanceVCPU = prism' pretty parse
           = PRCompoundPollster
             val
             (status ^. re pfInstanceStatus)
+{-# INLINE pdInstanceVCPU #-}
 
-data PDInstanceRAM = PDInstanceRAM PFInstanceStatus PFValue32
-     deriving (Eq, Show, Read)
+data PDInstanceRAM = PDInstanceRAM
+  {-# UNPACK #-} !PFInstanceStatus
+  {-# UNPACK #-} !PFValue32
+  deriving (Eq, Show, Read)
 
 pdInstanceRAM :: Prism' PRCompoundPollster PDInstanceRAM
 pdInstanceRAM = prism' pretty parse
@@ -87,9 +92,12 @@ pdInstanceRAM = prism' pretty parse
           = PRCompoundPollster
             val
             (status ^. re pfInstanceStatus)
+{-# INLINE pdInstanceRAM #-}
 
-data PDInstanceDisk = PDInstanceDisk PFInstanceStatus PFValue32
-     deriving (Eq, Show, Read)
+data PDInstanceDisk = PDInstanceDisk
+  {-# UNPACK #-} !PFInstanceStatus
+  {-# UNPACK #-} !PFValue32
+  deriving (Eq, Show, Read)
 
 pdInstanceDisk :: Prism' PRCompoundPollster PDInstanceDisk
 pdInstanceDisk = prism' pretty parse
@@ -101,9 +109,12 @@ pdInstanceDisk = prism' pretty parse
           = PRCompoundPollster
             val
             (status ^. re pfInstanceStatus)
+{-# INLINE pdInstanceDisk #-}
 
-data PDInstanceFlavor = PDInstanceFlavor PFInstanceStatus PFValueText
-     deriving (Eq, Show, Read)
+data PDInstanceFlavor = PDInstanceFlavor
+  {-# UNPACK #-} !PFInstanceStatus
+  {-# UNPACK #-} !PFValueText
+  deriving (Eq, Show, Read)
 
 pdInstanceFlavor :: FlavorMap -> Prism' PRCompoundPollster PDInstanceFlavor
 pdInstanceFlavor fm = prism' pretty parse
@@ -115,6 +126,7 @@ pdInstanceFlavor fm = prism' pretty parse
           = PRCompoundPollster
             (siphashID val)
             (status ^. re pfInstanceStatus)
+{-# INLINE pdInstanceFlavor #-}
 
 
 -- FROM COLLECTOR CODE


### PR DESCRIPTION
WIP do not merge

Trying to do what we can client-side to improve borel performance. On a specific tenancy query over a fixed 2 weeks:
- total: 4s
- just reading data from marquise and discards the points immediately: 0.1s

so we'll try to close the gap.
